### PR TITLE
Feat/project-setup 스킬 생성

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,92 +1,131 @@
-# C# Marketplace Plugin
+# CLAUDE.md
+
+이 파일은 **이 저장소를 개발/유지보수하는 Claude Code**를 위한 가이드입니다.
 
 ## Overview
 
-C#/.NET 및 WPF 개발을 위한 Claude Code 플러그인 (v1.5.0)
+C#/.NET 및 WPF 개발을 위한 Claude Code 플러그인 마켓플레이스 (v1.5.0)
 
-## Tech Stack
+- **GitHub**: `JeongHeonK/c-sharp-custom-marketplace`
+- **License**: MIT
+- **Requirements**: Claude Code 2.1.x+
 
-- Language: C# 12/13 (.NET 8/9)
-- UI Framework: WPF
-- Architecture: MVVM (CommunityToolkit.Mvvm)
-- Claude Code: 2.1.x+
+## Architecture
 
-## Code Principles
-
-### OOP Four Pillars
-- Encapsulation, Inheritance, Polymorphism, Abstraction
-
-### SOLID Principles (Required)
-- **S**ingle Responsibility Principle
-- **O**pen/Closed Principle
-- **L**iskov Substitution Principle
-- **I**nterface Segregation Principle
-- **D**ependency Inversion Principle
-
-### GoF Design Patterns
-- Apply design patterns in appropriate situations
-- Avoid over-engineering
-
-## Naming Conventions
-
-| Type | Convention | Example |
-|------|------------|---------|
-| Classes, Methods, Properties | PascalCase | `UserService`, `GetById` |
-| Local variables, Parameters | camelCase | `userId`, `isActive` |
-| Private fields | _camelCase | `_repository`, `_logger` |
-| Interfaces | I prefix | `IRepository`, `IUserService` |
-| Async methods | Async suffix | `GetByIdAsync` |
-
-## Project Structure (Recommended)
+### 3-tier 구조
 
 ```
-/src
-  /Models          - Domain models
-  /ViewModels      - MVVM ViewModels (partial classes)
-  /Views           - WPF XAML Views
-  /Services        - Business services
-  /Repositories    - Data access layer
-  /Messages        - Messenger message types
-  /Converters      - IValueConverter implementations
-  /Infrastructure  - Common infrastructure
-/tests
-  /UnitTests       - Unit tests
-  /IntegrationTests - Integration tests
+agents/   → 전문가 에이전트 (실제 작업 수행)
+skills/   → 사용자 호출 스킬 (워크플로우 정의, 에이전트에 위임)
+rules/    → 스킬 내부 knowledge-base (skills/*/rules/)
 ```
 
-## Available Tools
+### 모델 계층화
 
-### Agents
+| 역할 | 모델 | 예시 |
+|------|------|------|
+| 오케스트레이션 (복잡한 워크플로우 조율) | Opus | `csharp-tdd-develop`, `csharp-test-develop` |
+| 전문가 에이전트 (실제 코드 작성/분석) | Sonnet | `csharp-expert`, `wpf-expert` |
+| Knowledge-base (가이드라인 참조) | 미지정 (호출측 모델) | `csharp-best-practices` |
 
-| Agent | Description | Model |
-|-------|-------------|-------|
-| `csharp-expert` | C# code writing and analysis expert | Sonnet |
-| `wpf-expert` | WPF/MVVM expert | Sonnet |
+### 위임 패턴
 
-### Skills
+스킬이 오케스트레이터 역할을 하고, `csharp-expert` 에이전트에 실제 작업을 위임:
 
-| Skill | Description | Usage |
-|-------|-------------|-------|
-| `/csharp-code-review` | OOP/SOLID/GoF based code review | `/csharp-code-review [file]` |
-| `/csharp-refactor` | SOLID/Pattern/Modern C# refactoring | `/csharp-refactor [file] [type]` |
-| `/wpf-mvvm-generator` | MVVM code generation | `/wpf-mvvm-generator <entity> [type]` |
-| `/csharp-best-practices` | C# 12/.NET 8 코드 작성 가이드라인 | `/csharp-best-practices [topic]` |
-| `/csharp-tdd-develop` | TDD 기반 C# 개발 (Red-Green-Refactor) | `/csharp-tdd-develop <class>` |
-| `/csharp-test-develop` | 기존 코드에 테스트 코드 작성 | `/csharp-test-develop <class-or-file>` |
+```
+사용자 → /csharp-tdd-develop → (워크플로우 조율) → Task(csharp-expert) → 코드 작성
+```
 
-### MCP Servers
+### 스킬 context 모드
 
-- `context7`: Library/framework documentation search
-  - Usage: Include "use context7" in your prompt
-  - Example: "C# List<T> usage use context7"
-  - Supports .NET, WPF, NuGet package documentation
+| 모드 | 동작 | 사용처 |
+|------|------|--------|
+| `fork` | 독립 실행, 완료 후 결과 반환 | `csharp-code-review`, `csharp-refactor`, `wpf-mvvm-generator` |
+| `current` | 현재 컨텍스트에서 실행 | `csharp-tdd-develop`, `csharp-test-develop`, `csharp-best-practices`, `project-setup` |
 
-## Modern C# Features (Preferred)
+## File Structure
 
-- Primary constructors
-- Collection expressions `[1, 2, 3]`
-- required / init properties
-- Pattern matching
-- Record types
-- File-scoped namespaces
-- Raw string literals
+```
+/
+├── agents/
+│   ├── csharp-expert.md          # C#/.NET 전문가 에이전트
+│   └── wpf-expert.md             # WPF/MVVM 전문가 에이전트
+├── skills/
+│   ├── csharp-code-review/SKILL.md
+│   ├── csharp-refactor/SKILL.md
+│   ├── csharp-best-practices/
+│   │   ├── SKILL.md
+│   │   └── rules/                # 14개 규칙 파일 (cs12-*, modern-*)
+│   ├── csharp-tdd-develop/
+│   │   ├── SKILL.md
+│   │   └── scripts/              # test-detector.js
+│   ├── csharp-test-develop/
+│   │   ├── SKILL.md
+│   │   └── references/           # csharp-test-patterns.md
+│   ├── project-setup/
+│   │   ├── SKILL.md
+│   │   ├── scripts/              # setup.sh, setup.ps1
+│   │   ├── references/           # claude-md-template.md
+│   │   └── assets/hooks/         # hook 스크립트 (.sh + .ps1)
+│   └── wpf-mvvm-generator/SKILL.md
+├── .claude-plugin/
+│   └── marketplace.json          # 마켓플레이스 매니페스트
+├── .mcp.json                     # MCP 서버 설정 (context7)
+├── README.md                     # 영문 문서
+└── README.ko.md                  # 한국어 문서
+```
+
+## YAML Frontmatter 필수 필드
+
+### Agent (`agents/*.md`)
+
+```yaml
+name: <agent-name>
+description: <영문 설명>
+model: sonnet | opus | haiku
+permissionMode: default
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - Write
+  - Bash(dotnet *)
+  - Bash(nuget *)
+disallowedTools:
+  - WebSearch
+```
+
+### Skill (`skills/*/SKILL.md`)
+
+```yaml
+name: <skill-name>
+description: <설명>
+user-invocable: true
+context: fork | current
+model: sonnet | opus        # knowledge-base 스킬은 생략 가능
+argument-hint: "<hint>"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  # context: current + 위임 패턴인 경우 Task 포함
+```
+
+## Documentation Language
+
+| 파일 | 언어 |
+|------|------|
+| SKILL.md 본문 | 한국어 |
+| Agent .md 본문 | 영어 |
+| README.md | 영어 |
+| README.ko.md | 한국어 |
+| Git 커밋 메시지 | 한국어 (Conventional Commits) |
+
+## Version Management
+
+버전 변경 시 다음 3곳을 동시에 업데이트:
+
+1. `.claude-plugin/marketplace.json` — `metadata.version` + `plugins[0].version`
+2. `CLAUDE.md` — Overview 섹션의 버전 표기
+3. `README.md` / `README.ko.md` — 배지 및 Changelog 섹션

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,6 +24,7 @@ C# 및 WPF 개발을 위한 Claude Code 플러그인입니다. Modern C# 12/13, 
 | **csharp-best-practices** | C# 12/.NET 8 코드 작성 가이드라인 knowledge-base (12개 규칙, vercel-react-best-practices 3-tier 아키텍처 참조) |
 | **csharp-tdd-develop** | TDD 기반 C# 개발 (Red-Green-Refactor 워크플로우) |
 | **csharp-test-develop** | 기존 C# 코드에 테스트 코드 작성 |
+| **project-setup** | C#/.NET 프로젝트를 Claude Code용으로 초기화 (CLAUDE.md + Bash/PowerShell 컨텍스트 hook) — [agents.md outperforms skills](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) 기반 |
 
 ### MCP Servers
 | Server | 설명 |
@@ -108,6 +109,14 @@ c-sharp-marketplace/
 │   │   ├── SKILL.md         # 테스트 코드 작성 스킬
 │   │   └── references/
 │   │       └── csharp-test-patterns.md  # C# 테스트 패턴 가이드
+│   ├── project-setup/
+│   │   ├── SKILL.md         # 프로젝트 초기화 스킬
+│   │   ├── scripts/
+│   │   │   ├── setup.sh     # Hook 설치 (Bash)
+│   │   │   └── setup.ps1    # Hook 설치 (PowerShell)
+│   │   ├── references/
+│   │   │   └── claude-md-template.md  # CLAUDE.md 생성 템플릿
+│   │   └── assets/hooks/    # Hook 스크립트 (.sh + .ps1)
 │   └── wpf-mvvm-generator/
 │       └── SKILL.md         # MVVM 생성 스킬
 ├── .mcp.json                # MCP 서버 설정
@@ -179,6 +188,14 @@ c-sharp-marketplace/
 /wpf-mvvm-generator User                    # User에 대한 전체 MVVM 생성
 /wpf-mvvm-generator Product viewmodel       # ProductViewModel만 생성
 /wpf-mvvm-generator Order view              # OrderView만 생성
+```
+
+#### 프로젝트 셋업
+```
+/project-setup                              # 현재 프로젝트 초기화
+/project-setup init /path/to/project        # 특정 프로젝트 초기화
+/project-setup migrate                      # 기존 CLAUDE.md에 섹션 추가
+/project-setup hooks                        # hook 스크립트만 설치
 ```
 
 ### MCP 서버 (Context7)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Claude Code plugin for C# and WPF development. Provides expert agents and code
 | **csharp-best-practices** | C# 12/.NET 8 coding guidelines knowledge-base (12 rules, 3-tier architecture inspired by vercel-react-best-practices) |
 | **csharp-tdd-develop** | TDD-based C# development (Red-Green-Refactor workflow) |
 | **csharp-test-develop** | Write test code for existing C# classes |
+| **project-setup** | Initialize C#/.NET project for Claude Code (CLAUDE.md + context hooks for Bash/PowerShell) — based on [agents.md outperforms skills](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) |
 
 ### MCP Servers
 | Server | Description |
@@ -110,6 +111,14 @@ c-sharp-marketplace/
 │   │   ├── SKILL.md         # Test code writing skill
 │   │   └── references/
 │   │       └── csharp-test-patterns.md  # C# test patterns guide
+│   ├── project-setup/
+│   │   ├── SKILL.md         # Project initialization skill
+│   │   ├── scripts/
+│   │   │   ├── setup.sh     # Hook setup (Bash)
+│   │   │   └── setup.ps1    # Hook setup (PowerShell)
+│   │   ├── references/
+│   │   │   └── claude-md-template.md  # CLAUDE.md generation template
+│   │   └── assets/hooks/    # Hook scripts (.sh + .ps1)
 │   └── wpf-mvvm-generator/
 │       └── SKILL.md         # MVVM generation skill
 ├── .mcp.json                # MCP server configuration
@@ -181,6 +190,14 @@ Agents can be invoked directly using `@agent-name`, or Claude Code will automati
 /wpf-mvvm-generator User                    # Generate full MVVM for User
 /wpf-mvvm-generator Product viewmodel       # Generate ProductViewModel only
 /wpf-mvvm-generator Order view              # Generate OrderView only
+```
+
+#### Project Setup
+```
+/project-setup                              # Initialize current project
+/project-setup init /path/to/project        # Initialize specific project
+/project-setup migrate                      # Add sections to existing CLAUDE.md
+/project-setup hooks                        # Install hook scripts only
 ```
 
 ### MCP Server (Context7)

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: project-setup
+description: C#/.NET 프로젝트를 Claude Code용으로 초기화. CLAUDE.md 생성 + 컨텍스트 hook 설치 (Bash/PowerShell). Use when setting up new C# projects for Claude Code, migrating existing projects, or updating context hooks.
+user-invocable: true
+context: current
+model: sonnet
+argument-hint: "<init|migrate|hooks> [project-path]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+---
+
+# Project Setup
+
+C#/.NET 프로젝트를 Claude Code용으로 초기화하는 스킬. CLAUDE.md 생성과 컨텍스트 hook(Bash/PowerShell)을 설치합니다.
+
+## Arguments
+
+- `$ARGUMENTS[0]`: 서브커맨드 (`init` | `migrate` | `hooks`)
+- `$ARGUMENTS[1]`: 대상 프로젝트 경로 (선택, 기본값: 현재 디렉토리)
+
+### 서브커맨드
+
+| 커맨드 | 설명 |
+|--------|------|
+| `init` | 새 프로젝트 초기화 (CLAUDE.md 생성 + hook 설치) |
+| `migrate` | 기존 CLAUDE.md에 Context Management 섹션 추가 + hook 설치 |
+| `hooks` | hook 스크립트만 설치/업데이트 |
+
+---
+
+## Workflow
+
+### Step 1: 인자 파싱
+
+```
+서브커맨드 = $ARGUMENTS[0] (기본값: "init")
+대상 경로 = $ARGUMENTS[1] (기본값: 현재 작업 디렉토리)
+```
+
+서브커맨드가 `init`, `migrate`, `hooks` 중 하나가 아니면:
+- 첫 번째 인자를 경로로 간주하고 서브커맨드를 `init`으로 설정
+
+---
+
+### Step 2: C# 프로젝트 감지 (init/migrate)
+
+`hooks` 서브커맨드인 경우 이 단계 건너뛰기.
+
+1. Glob으로 대상 경로에서 `.sln`, `.csproj` 파일 탐색
+2. `.csproj` 파일들을 Read하여 다음 정보 추출:
+   - `<TargetFramework>` (예: net8.0, net9.0)
+   - `<OutputType>` (예: WinExe, Exe, Library)
+   - `<UseWPF>true</UseWPF>` 여부
+   - `<PackageReference>` 목록 (주요 NuGet 패키지)
+3. 프로젝트 유형 판별:
+
+| OutputType | UseWPF | 판별 결과 |
+|------------|--------|-----------|
+| WinExe | true | WPF Application |
+| Exe | - | Console Application |
+| Library | - | Class Library |
+| - | - (WebAPI 패키지 있음) | ASP.NET WebAPI |
+| - | - (테스트 패키지 있음) | Test Project |
+
+4. 솔루션 구조 파악:
+   - `.sln` 파일에서 프로젝트 목록 추출
+   - src/tests 디렉토리 구조 확인
+
+---
+
+### Step 3: Hook 스크립트 설치
+
+**OS 감지**: Bash 도구로 OS를 확인하여 적절한 스크립트 선택:
+- `uname` 명령어로 OS 확인
+- Windows (MINGW/MSYS/CYGWIN/WSL 아닌 환경) → PowerShell 사용
+- Linux/macOS/WSL → Bash 사용
+
+#### Bash 환경 (Linux/macOS/WSL):
+```bash
+bash <plugin-path>/skills/project-setup/scripts/setup.sh <target-dir>
+```
+
+#### PowerShell 환경 (Windows):
+```powershell
+pwsh <plugin-path>/skills/project-setup/scripts/setup.ps1 -TargetDir <target-dir>
+```
+
+여기서 `<plugin-path>`는 이 SKILL.md 파일이 위치한 플러그인의 루트 경로입니다.
+이 경로를 확인하려면 Glob으로 `**/skills/project-setup/scripts/setup.sh` 또는 `**/skills/project-setup/scripts/setup.ps1`을 검색하세요.
+
+**setup 스크립트가 수행하는 작업:**
+- `assets/hooks/*` (.sh + .ps1) → `<target>/scripts/hooks/`로 복사
+- `chmod +x` 설정 (bash 스크립트)
+- `.claude/context/`, `.claude/learnings/` 디렉토리 생성
+
+---
+
+### Step 4: CLAUDE.md 생성 또는 업데이트
+
+#### init 서브커맨드: CLAUDE.md 신규 생성
+
+Write 도구로 `<target>/CLAUDE.md` 생성. `references/claude-md-template.md` 템플릿을 참조하여 Step 2에서 감지한 정보로 `{변수}`를 치환합니다.
+
+1. Read로 `references/claude-md-template.md` 읽기
+2. 템플릿의 `{변수}`를 Step 2 감지 결과로 치환
+3. 조건부 섹션 적용 (WPF가 아닌 경우 `/wpf-mvvm-generator` 관련 항목 제거)
+4. Write로 `<target>/CLAUDE.md` 생성
+
+#### migrate 서브커맨드: 기존 CLAUDE.md에 섹션 추가
+
+1. 기존 CLAUDE.md를 Read
+2. `## Context Management` 섹션이 없으면 Edit으로 추가
+3. `## Skill Invocation Guidelines` 섹션이 없으면 Edit으로 추가
+4. 기존 내용은 절대 삭제하지 않음
+
+---
+
+### Step 5: settings.local.json 업데이트
+
+1. Read로 `<target>/.claude/settings.local.json` 읽기 (없으면 새로 생성)
+2. Step 3에서 감지한 OS에 따라 hook command 결정:
+   - **Bash 환경**: `bash scripts/hooks/<name>.sh`
+   - **PowerShell 환경**: `pwsh scripts/hooks/<name>.ps1`
+3. 기존 hooks 설정이 있으면 병합, 없으면 새로 추가:
+
+#### Bash 환경 (Linux/macOS/WSL):
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/session-complete.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### PowerShell 환경 (Windows):
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh scripts/hooks/session-start.ps1"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh scripts/hooks/pre-compact.ps1"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh scripts/hooks/session-complete.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+4. 기존 설정이 있으면 `hooks` 키에 병합 (기존 hook은 유지)
+
+---
+
+### Step 6: 검증 체크리스트
+
+모든 설치가 완료된 후 검증:
+
+- [ ] `scripts/hooks/session-start.sh` + `.ps1` 존재
+- [ ] `scripts/hooks/pre-compact.sh` + `.ps1` 존재
+- [ ] `scripts/hooks/session-complete.sh` + `.ps1` 존재
+- [ ] `scripts/hooks/lib/utils.sh` + `utils.ps1` 존재
+- [ ] Bash 스크립트 실행 권한 확인 (Linux/macOS)
+- [ ] `.claude/context/` 디렉토리 존재
+- [ ] `.claude/learnings/` 디렉토리 존재
+- [ ] `.claude/settings.local.json`에 hook 등록 확인
+- [ ] `CLAUDE.md`에 Skill Invocation Guidelines 섹션 존재 (init/migrate)
+
+검증 실패 항목이 있으면 사용자에게 알리고 수동 조치 방법 안내.
+
+---
+
+## 현재 전달받은 인자
+
+**ARGUMENTS**: $ARGUMENTS
+
+## 실행 지시
+
+위 ARGUMENTS를 파싱하여 워크플로우를 시작하세요.
+
+**ARGUMENTS가 비어있으면** `init`을 기본 서브커맨드로 사용하고, 현재 디렉토리를 대상으로 합니다.
+
+**호출 예시:**
+- `/project-setup` → init + 현재 디렉토리
+- `/project-setup init` → init + 현재 디렉토리
+- `/project-setup init /path/to/project` → init + 지정 경로
+- `/project-setup migrate` → 기존 CLAUDE.md에 섹션 추가
+- `/project-setup hooks` → hook 스크립트만 설치
+- `/project-setup /path/to/project` → init + 지정 경로 (경로가 서브커맨드가 아닌 경우)
+
+---
+
+## Error Handling
+
+| 상황 | 처리 |
+|------|------|
+| .csproj 없음 | 경고 출력 후 기본 CLAUDE.md 생성 |
+| CLAUDE.md 이미 존재 (init) | 사용자에게 덮어쓰기 확인 또는 migrate 제안 |
+| settings.local.json 파싱 실패 | 백업 후 새로 생성 |
+| setup 스크립트 실행 실패 | 에러 내용 출력 + 수동 설치 방법 안내 |
+
+---
+
+## .gitignore 안내
+
+설치 완료 후 사용자에게 `.gitignore`에 다음 추가를 안내:
+
+```
+# Claude Code context (auto-generated, session-specific)
+.claude/context/
+.claude/learnings/
+```
+
+`scripts/hooks/`는 팀 공유를 위해 커밋하는 것을 권장.

--- a/skills/project-setup/assets/hooks/lib/utils.ps1
+++ b/skills/project-setup/assets/hooks/lib/utils.ps1
@@ -1,0 +1,83 @@
+# utils.ps1 — 공유 PowerShell 유틸리티
+# Hook 스크립트에서 . (dot-source)하여 사용
+
+# --- Git 유틸 ---
+
+function Get-GitBranch {
+    try {
+        $branch = git rev-parse --abbrev-ref HEAD 2>$null
+        if ($LASTEXITCODE -eq 0 -and $branch) { return $branch }
+    } catch {}
+    return "unknown"
+}
+
+function Get-GitStatusShort {
+    try { return (git status --short 2>$null) } catch { return "" }
+}
+
+function Get-GitDiffStat {
+    try { return (git diff --stat 2>$null) } catch { return "" }
+}
+
+function Get-GitRecentCommits {
+    param([int]$Count = 5)
+    try { return (git log --oneline -n $Count 2>$null) } catch { return "" }
+}
+
+# --- 시간 유틸 ---
+
+function Get-Timestamp {
+    return (Get-Date -Format "yyyyMMdd_HHmmss")
+}
+
+function Get-FormattedDate {
+    return (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+}
+
+# --- 파일 유틸 ---
+
+function Get-RecentFile {
+    param(
+        [string]$Dir,
+        [string]$Pattern,
+        [int]$Count = 1
+    )
+    if (-not (Test-Path $Dir)) { return @() }
+    return Get-ChildItem -Path $Dir -Filter $Pattern -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First $Count
+}
+
+function Remove-OldFiles {
+    param(
+        [string]$Dir,
+        [string]$Pattern,
+        [int]$Keep = 3
+    )
+    if (-not (Test-Path $Dir)) { return }
+    $files = Get-ChildItem -Path $Dir -Filter $Pattern -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -Skip $Keep
+    foreach ($f in $files) {
+        Remove-Item $f.FullName -Force
+    }
+}
+
+function Ensure-Dir {
+    param([string]$Dir)
+    if (-not (Test-Path $Dir)) {
+        New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+    }
+}
+
+# --- stdin 파싱 유틸 ---
+
+function Read-StdinJson {
+    try {
+        $input_text = [Console]::In.ReadToEnd()
+        if ($input_text) {
+            return $input_text | ConvertFrom-Json -ErrorAction SilentlyContinue
+        }
+    } catch {}
+    return $null
+}

--- a/skills/project-setup/assets/hooks/lib/utils.sh
+++ b/skills/project-setup/assets/hooks/lib/utils.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# utils.sh — 공유 bash 유틸리티
+# Hook 스크립트에서 source하여 사용
+
+# --- Git 유틸 ---
+
+git_branch() {
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && echo "$branch" || echo "unknown"
+}
+
+git_status_short() {
+    git status --short 2>/dev/null || echo ""
+}
+
+git_diff_stat() {
+    git diff --stat 2>/dev/null || echo ""
+}
+
+git_recent_commits() {
+    local count="${1:-5}"
+    git log --oneline -n "$count" 2>/dev/null || echo ""
+}
+
+# --- 시간 유틸 ---
+
+timestamp() {
+    date +%Y%m%d_%H%M%S
+}
+
+format_date() {
+    date +"%Y-%m-%d %H:%M:%S"
+}
+
+# --- 파일 유틸 ---
+
+# 디렉토리에서 패턴에 맞는 최근 파일 반환
+# Usage: get_recent_file <dir> <pattern> [count]
+get_recent_file() {
+    local dir="$1"
+    local pattern="$2"
+    local count="${3:-1}"
+
+    if [ ! -d "$dir" ]; then
+        return
+    fi
+
+    # shellcheck disable=SC2012
+    ls -t "$dir"/$pattern 2>/dev/null | head -n "$count"
+}
+
+# 디렉토리에서 오래된 파일 삭제 (최근 N개만 유지)
+# Usage: prune_files <dir> <pattern> <keep_count>
+prune_files() {
+    local dir="$1"
+    local pattern="$2"
+    local keep="${3:-3}"
+
+    if [ ! -d "$dir" ]; then
+        return
+    fi
+
+    # shellcheck disable=SC2012
+    local files
+    files=$(ls -t "$dir"/$pattern 2>/dev/null | tail -n +$((keep + 1)))
+
+    if [ -n "$files" ]; then
+        echo "$files" | xargs rm -f
+    fi
+}
+
+# 디렉토리 존재 확인 및 생성
+ensure_dir() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+    fi
+}
+
+# --- stdin 파싱 유틸 ---
+
+# stdin에서 JSON-like 입력 읽기
+parse_stdin() {
+    cat
+}
+
+# 간단한 grep 기반 JSON 필드 추출
+# Usage: echo '{"key":"value"}' | json_field "key"
+json_field() {
+    local field="$1"
+    grep -o "\"$field\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" 2>/dev/null | head -1 | sed 's/.*: *"\(.*\)"/\1/' || echo ""
+}

--- a/skills/project-setup/assets/hooks/pre-compact.ps1
+++ b/skills/project-setup/assets/hooks/pre-compact.ps1
@@ -1,0 +1,58 @@
+# pre-compact.ps1 — PreCompact hook
+# 컨텍스트 압축 전 현재 상태를 저장합니다.
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$ScriptDir/lib/utils.ps1"
+
+$ContextDir = ".claude/context"
+Ensure-Dir $ContextDir
+
+$ts = Get-Timestamp
+$stateFile = "$ContextDir/state_$ts.md"
+
+# 현재 상태 수집
+$content = @()
+$content += "## State Snapshot"
+$content += ""
+$content += "**Branch**: $(Get-GitBranch)"
+$content += "**Time**: $(Get-FormattedDate)"
+$content += ""
+
+# Git diff 통계
+$diffStat = Get-GitDiffStat
+if ($diffStat) {
+    $content += "### Working Changes"
+    $content += '```'
+    $content += $diffStat
+    $content += '```'
+    $content += ""
+}
+
+# 최근 커밋
+$commits = Get-GitRecentCommits -Count 5
+if ($commits) {
+    $content += "### Recent Commits"
+    $content += '```'
+    $content += $commits
+    $content += '```'
+    $content += ""
+}
+
+# 미커밋 변경 파일 목록
+$status = Get-GitStatusShort
+if ($status) {
+    $content += "### Uncommitted Files"
+    $content += '```'
+    $content += $status
+    $content += '```'
+    $content += ""
+}
+
+$content | Out-File -FilePath $stateFile -Encoding utf8
+
+# 최근 3개만 유지
+Remove-OldFiles -Dir $ContextDir -Pattern "state_*.md" -Keep 3
+
+Write-Output "State saved to $stateFile"

--- a/skills/project-setup/assets/hooks/pre-compact.sh
+++ b/skills/project-setup/assets/hooks/pre-compact.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# pre-compact.sh — PreCompact hook
+# 컨텍스트 압축 전 현재 상태를 저장합니다.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/utils.sh
+source "$SCRIPT_DIR/lib/utils.sh"
+
+CONTEXT_DIR=".claude/context"
+ensure_dir "$CONTEXT_DIR"
+
+TS=$(timestamp)
+STATE_FILE="$CONTEXT_DIR/state_${TS}.md"
+
+# 현재 상태 수집
+{
+    echo "## State Snapshot"
+    echo ""
+    echo "**Branch**: $(git_branch)"
+    echo "**Time**: $(format_date)"
+    echo ""
+
+    # Git diff 통계
+    DIFF_STAT=$(git_diff_stat)
+    if [ -n "$DIFF_STAT" ]; then
+        echo "### Working Changes"
+        echo '```'
+        echo "$DIFF_STAT"
+        echo '```'
+        echo ""
+    fi
+
+    # 최근 커밋
+    COMMITS=$(git_recent_commits 5)
+    if [ -n "$COMMITS" ]; then
+        echo "### Recent Commits"
+        echo '```'
+        echo "$COMMITS"
+        echo '```'
+        echo ""
+    fi
+
+    # 미커밋 변경 파일 목록
+    STATUS=$(git_status_short)
+    if [ -n "$STATUS" ]; then
+        echo "### Uncommitted Files"
+        echo '```'
+        echo "$STATUS"
+        echo '```'
+        echo ""
+    fi
+} > "$STATE_FILE"
+
+# 최근 3개만 유지
+prune_files "$CONTEXT_DIR" "state_*.md" 3
+
+echo "State saved to $STATE_FILE"

--- a/skills/project-setup/assets/hooks/session-complete.ps1
+++ b/skills/project-setup/assets/hooks/session-complete.ps1
@@ -1,0 +1,48 @@
+# session-complete.ps1 — Stop hook
+# 세션 종료 시 학습 내용을 기록합니다.
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$ScriptDir/lib/utils.ps1"
+
+$LearningsDir = ".claude/learnings"
+Ensure-Dir $LearningsDir
+
+$ts = Get-Timestamp
+$sessionFile = "$LearningsDir/session_$ts.md"
+
+# 세션 정보 수집
+$content = @()
+$content += "## Session Summary"
+$content += ""
+$content += "**Branch**: $(Get-GitBranch)"
+$content += "**Time**: $(Get-FormattedDate)"
+$content += ""
+
+# 최근 커밋
+$commits = Get-GitRecentCommits -Count 10
+if ($commits) {
+    $content += "### Commits This Session"
+    $content += '```'
+    $content += $commits
+    $content += '```'
+    $content += ""
+}
+
+# 미커밋 변경사항
+$status = Get-GitStatusShort
+if ($status) {
+    $content += "### Uncommitted Changes"
+    $content += '```'
+    $content += $status
+    $content += '```'
+    $content += ""
+}
+
+$content | Out-File -FilePath $sessionFile -Encoding utf8
+
+# 최근 5개만 유지
+Remove-OldFiles -Dir $LearningsDir -Pattern "session_*.md" -Keep 5
+
+Write-Output "Session recorded to $sessionFile"

--- a/skills/project-setup/assets/hooks/session-complete.sh
+++ b/skills/project-setup/assets/hooks/session-complete.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# session-complete.sh — Stop hook
+# 세션 종료 시 학습 내용을 기록합니다.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/utils.sh
+source "$SCRIPT_DIR/lib/utils.sh"
+
+LEARNINGS_DIR=".claude/learnings"
+ensure_dir "$LEARNINGS_DIR"
+
+TS=$(timestamp)
+SESSION_FILE="$LEARNINGS_DIR/session_${TS}.md"
+
+# 세션 정보 수집
+{
+    echo "## Session Summary"
+    echo ""
+    echo "**Branch**: $(git_branch)"
+    echo "**Time**: $(format_date)"
+    echo ""
+
+    # 최근 커밋 (이 세션에서 작성된 것들)
+    COMMITS=$(git_recent_commits 10)
+    if [ -n "$COMMITS" ]; then
+        echo "### Commits This Session"
+        echo '```'
+        echo "$COMMITS"
+        echo '```'
+        echo ""
+    fi
+
+    # 미커밋 변경사항
+    STATUS=$(git_status_short)
+    if [ -n "$STATUS" ]; then
+        echo "### Uncommitted Changes"
+        echo '```'
+        echo "$STATUS"
+        echo '```'
+        echo ""
+    fi
+} > "$SESSION_FILE"
+
+# 최근 5개만 유지
+prune_files "$LEARNINGS_DIR" "session_*.md" 5
+
+echo "Session recorded to $SESSION_FILE"

--- a/skills/project-setup/assets/hooks/session-start.ps1
+++ b/skills/project-setup/assets/hooks/session-start.ps1
@@ -1,0 +1,53 @@
+# session-start.ps1 — SessionStart hook
+# stdin으로 hook 데이터를 받고, stdout으로 컨텍스트를 출력합니다.
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$ScriptDir/lib/utils.ps1"
+
+$ContextDir = ".claude/context"
+$LearningsDir = ".claude/learnings"
+
+Ensure-Dir $ContextDir
+Ensure-Dir $LearningsDir
+
+# stdin 읽기
+$json = Read-StdinJson
+$source = if ($json -and $json.source) { $json.source } else { "startup" }
+
+# --- 컨텍스트 출력 ---
+
+Write-Output "## Session Context"
+Write-Output ""
+Write-Output "**Branch**: $(Get-GitBranch)"
+Write-Output "**Time**: $(Get-FormattedDate)"
+Write-Output ""
+
+# Git 상태 출력
+$status = Get-GitStatusShort
+if ($status) {
+    Write-Output "### Uncommitted Changes"
+    Write-Output '```'
+    Write-Output $status
+    Write-Output '```'
+    Write-Output ""
+}
+
+# compact 복구인 경우 이전 상태 파일 읽기
+if ($source -eq "compact") {
+    $recentState = Get-RecentFile -Dir $ContextDir -Pattern "state_*.md" -Count 1
+    if ($recentState) {
+        Write-Output "### Restored State (pre-compact)"
+        Get-Content $recentState.FullName
+        Write-Output ""
+    }
+}
+
+# 최근 세션 학습 내용 읽기
+$recentLearning = Get-RecentFile -Dir $LearningsDir -Pattern "session_*.md" -Count 1
+if ($recentLearning) {
+    Write-Output "### Previous Session Learnings"
+    Get-Content $recentLearning.FullName
+    Write-Output ""
+}

--- a/skills/project-setup/assets/hooks/session-start.sh
+++ b/skills/project-setup/assets/hooks/session-start.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# session-start.sh — SessionStart hook
+# stdin으로 hook 데이터를 받고, stdout으로 컨텍스트를 출력합니다.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/utils.sh
+source "$SCRIPT_DIR/lib/utils.sh"
+
+CONTEXT_DIR=".claude/context"
+LEARNINGS_DIR=".claude/learnings"
+
+ensure_dir "$CONTEXT_DIR"
+ensure_dir "$LEARNINGS_DIR"
+
+# stdin 읽기 (SessionStart hook은 JSON 데이터를 받음)
+INPUT=$(parse_stdin)
+SOURCE=$(echo "$INPUT" | json_field "source")
+SOURCE="${SOURCE:-startup}"
+
+# --- 컨텍스트 출력 ---
+
+echo "## Session Context"
+echo ""
+echo "**Branch**: $(git_branch)"
+echo "**Time**: $(format_date)"
+echo ""
+
+# Git 상태 출력
+STATUS=$(git_status_short)
+if [ -n "$STATUS" ]; then
+    echo "### Uncommitted Changes"
+    echo '```'
+    echo "$STATUS"
+    echo '```'
+    echo ""
+fi
+
+# compact 복구인 경우 이전 상태 파일 읽기
+if [ "$SOURCE" = "compact" ]; then
+    RECENT_STATE=$(get_recent_file "$CONTEXT_DIR" "state_*.md" 1)
+    if [ -n "$RECENT_STATE" ]; then
+        echo "### Restored State (pre-compact)"
+        cat "$RECENT_STATE"
+        echo ""
+    fi
+fi
+
+# 최근 세션 학습 내용 읽기
+RECENT_LEARNING=$(get_recent_file "$LEARNINGS_DIR" "session_*.md" 1)
+if [ -n "$RECENT_LEARNING" ]; then
+    echo "### Previous Session Learnings"
+    cat "$RECENT_LEARNING"
+    echo ""
+fi

--- a/skills/project-setup/references/claude-md-template.md
+++ b/skills/project-setup/references/claude-md-template.md
@@ -1,0 +1,97 @@
+# CLAUDE.md Template
+
+이 템플릿은 `/project-setup init`이 대상 프로젝트에 생성하는 CLAUDE.md의 구조입니다.
+`{변수}`는 Step 2에서 감지한 프로젝트 정보로 치환합니다.
+
+---
+
+```markdown
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## Project Overview
+
+- **Type**: {프로젝트 유형}
+- **Framework**: {TargetFramework}
+- **Solution**: {솔루션 파일명}
+
+## Build & Test Commands
+
+- Build: `dotnet build`
+- Test: `dotnet test`
+- Run: `dotnet run --project {메인 프로젝트 경로}`
+
+## Project Structure
+
+{감지된 프로젝트 구조}
+
+## Key Dependencies
+
+{주요 NuGet 패키지 목록}
+
+## Coding Conventions
+
+- Follow C# naming conventions (PascalCase for public members, _camelCase for private fields)
+- Use file-scoped namespaces
+- Prefer primary constructors where appropriate
+- Use nullable reference types
+
+## Context Management
+
+This project uses automated context hooks to maintain session state.
+
+### Hook Scripts (Bash / PowerShell)
+- `scripts/hooks/session-start.sh` / `.ps1` — Restores context on session start
+- `scripts/hooks/pre-compact.sh` / `.ps1` — Saves state before context compaction
+- `scripts/hooks/session-complete.sh` / `.ps1` — Records session learnings on exit
+
+### Context Directories
+- `.claude/context/` — Session state snapshots (auto-managed)
+- `.claude/learnings/` — Cross-session learnings (auto-managed)
+
+## Skill Invocation Guidelines
+
+This project uses the c-sharp-marketplace plugin. Follow these instructions exactly.
+
+### Before Writing Code
+- Invoke `/csharp-best-practices` to review relevant C# 12 guidelines before writing code.
+- For WPF features, invoke `/wpf-mvvm-generator <entity>` to scaffold MVVM boilerplate first.
+
+### During Development
+- For new features, invoke `/csharp-tdd-develop <class>` to follow the TDD Red-Green-Refactor workflow.
+- When adding tests to existing code, invoke `/csharp-test-develop <file>` instead.
+
+### After Writing Code
+- Before committing, invoke `/csharp-code-review <file>` on all modified .cs files.
+- If SOLID violations or code smells are found, invoke `/csharp-refactor <file> <type>`.
+
+### Quick Reference
+| Task | Skill to Invoke |
+|------|----------------|
+| C# 12 feature syntax | `/csharp-best-practices <topic>` |
+| Create WPF ViewModel/View | `/wpf-mvvm-generator <entity>` |
+| Develop new class with TDD | `/csharp-tdd-develop <class>` |
+| Add tests to existing code | `/csharp-test-develop <file>` |
+| Review code quality | `/csharp-code-review <file>` |
+| Refactor existing code | `/csharp-refactor <file> <type>` |
+| Search .NET documentation | Include "use context7" in prompt |
+```
+
+---
+
+## 치환 규칙
+
+| 변수 | 소스 | 예시 |
+|------|------|------|
+| `{프로젝트 유형}` | Step 2 판별 결과 | WPF Application, Console Application |
+| `{TargetFramework}` | `.csproj` `<TargetFramework>` | net8.0, net9.0 |
+| `{솔루션 파일명}` | `.sln` 파일명 | MyApp.sln |
+| `{메인 프로젝트 경로}` | OutputType이 Exe/WinExe인 `.csproj` 경로 | src/MyApp/MyApp.csproj |
+| `{감지된 프로젝트 구조}` | 디렉토리 트리 | src/, tests/ 구조 |
+| `{주요 NuGet 패키지 목록}` | `<PackageReference>` 항목 | CommunityToolkit.Mvvm 등 |
+
+## 조건부 섹션
+
+- **WPF 프로젝트가 아닌 경우**: "Before Writing Code"에서 `/wpf-mvvm-generator` 항목 제거, Quick Reference에서 해당 행 제거
+- **테스트 프로젝트가 없는 경우**: Build & Test Commands에서 Test 행 제거

--- a/skills/project-setup/scripts/setup.ps1
+++ b/skills/project-setup/scripts/setup.ps1
@@ -1,0 +1,49 @@
+# setup.ps1 — Hook 파일 복사 + 디렉토리 생성
+# Usage: pwsh setup.ps1 <target-dir>
+#
+# 이 스크립트는 최소한의 작업만 수행합니다:
+# - assets/hooks/* → <target>/scripts/hooks/ 복사
+# - .claude/context/, .claude/learnings/ 디렉토리 생성
+#
+# CLAUDE.md 및 settings.local.json 조작은 Claude 도구가 담당합니다.
+
+param(
+    [string]$TargetDir = "."
+)
+
+$ErrorActionPreference = "Stop"
+
+# 절대 경로로 변환
+$TargetDir = Resolve-Path $TargetDir -ErrorAction Stop
+
+# 이 스크립트의 위치 기준으로 assets/hooks 경로 결정
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$AssetsDir = Join-Path (Split-Path -Parent $ScriptDir) "assets/hooks"
+
+if (-not (Test-Path $AssetsDir)) {
+    Write-Error "Assets directory not found: $AssetsDir"
+    exit 1
+}
+
+# 1. Hook 파일 복사
+$HooksDest = Join-Path $TargetDir "scripts/hooks"
+New-Item -ItemType Directory -Path "$HooksDest/lib" -Force | Out-Null
+
+# Bash 스크립트
+Copy-Item "$AssetsDir/lib/utils.sh" "$HooksDest/lib/utils.sh" -Force
+Copy-Item "$AssetsDir/session-start.sh" "$HooksDest/session-start.sh" -Force
+Copy-Item "$AssetsDir/pre-compact.sh" "$HooksDest/pre-compact.sh" -Force
+Copy-Item "$AssetsDir/session-complete.sh" "$HooksDest/session-complete.sh" -Force
+
+# PowerShell 스크립트
+Copy-Item "$AssetsDir/lib/utils.ps1" "$HooksDest/lib/utils.ps1" -Force
+Copy-Item "$AssetsDir/session-start.ps1" "$HooksDest/session-start.ps1" -Force
+Copy-Item "$AssetsDir/pre-compact.ps1" "$HooksDest/pre-compact.ps1" -Force
+Copy-Item "$AssetsDir/session-complete.ps1" "$HooksDest/session-complete.ps1" -Force
+
+# 2. Claude 컨텍스트 디렉토리 생성
+New-Item -ItemType Directory -Path "$TargetDir/.claude/context" -Force | Out-Null
+New-Item -ItemType Directory -Path "$TargetDir/.claude/learnings" -Force | Out-Null
+
+Write-Output "OK: Hook scripts installed to $HooksDest"
+Write-Output "OK: Context directories created at $TargetDir/.claude/"

--- a/skills/project-setup/scripts/setup.sh
+++ b/skills/project-setup/scripts/setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# setup.sh — Hook 파일 복사 + 디렉토리 생성
+# Usage: bash setup.sh <target-dir>
+#
+# 이 스크립트는 최소한의 작업만 수행합니다:
+# - assets/hooks/* → <target>/scripts/hooks/ 복사
+# - chmod +x 설정
+# - .claude/context/, .claude/learnings/ 디렉토리 생성
+#
+# CLAUDE.md 및 settings.local.json 조작은 Claude 도구가 담당합니다.
+
+set -euo pipefail
+
+TARGET_DIR="${1:-.}"
+
+# 절대 경로로 변환
+TARGET_DIR="$(cd "$TARGET_DIR" 2>/dev/null && pwd)" || {
+    echo "ERROR: Target directory does not exist: $1" >&2
+    exit 1
+}
+
+# 이 스크립트의 위치 기준으로 assets/hooks 경로 결정
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASSETS_DIR="$SCRIPT_DIR/../assets/hooks"
+
+if [ ! -d "$ASSETS_DIR" ]; then
+    echo "ERROR: Assets directory not found: $ASSETS_DIR" >&2
+    exit 1
+fi
+
+# 1. Hook 파일 복사
+HOOKS_DEST="$TARGET_DIR/scripts/hooks"
+mkdir -p "$HOOKS_DEST/lib"
+
+# Bash 스크립트
+cp "$ASSETS_DIR/lib/utils.sh" "$HOOKS_DEST/lib/utils.sh"
+cp "$ASSETS_DIR/session-start.sh" "$HOOKS_DEST/session-start.sh"
+cp "$ASSETS_DIR/pre-compact.sh" "$HOOKS_DEST/pre-compact.sh"
+cp "$ASSETS_DIR/session-complete.sh" "$HOOKS_DEST/session-complete.sh"
+
+# PowerShell 스크립트
+cp "$ASSETS_DIR/lib/utils.ps1" "$HOOKS_DEST/lib/utils.ps1"
+cp "$ASSETS_DIR/session-start.ps1" "$HOOKS_DEST/session-start.ps1"
+cp "$ASSETS_DIR/pre-compact.ps1" "$HOOKS_DEST/pre-compact.ps1"
+cp "$ASSETS_DIR/session-complete.ps1" "$HOOKS_DEST/session-complete.ps1"
+
+# 2. 실행 권한 설정 (bash)
+chmod +x "$HOOKS_DEST/session-start.sh"
+chmod +x "$HOOKS_DEST/pre-compact.sh"
+chmod +x "$HOOKS_DEST/session-complete.sh"
+
+# 3. Claude 컨텍스트 디렉토리 생성
+mkdir -p "$TARGET_DIR/.claude/context"
+mkdir -p "$TARGET_DIR/.claude/learnings"
+
+echo "OK: Hook scripts installed to $HOOKS_DEST"
+echo "OK: Context directories created at $TARGET_DIR/.claude/"


### PR DESCRIPTION
## Summary

C#/.NET 프로젝트를 Claude Code용으로 초기화하는 `project-setup` 스킬 추가.

Closes #7

## Changes

- ✨ SKILL.md (276줄, init/migrate/hooks 서브커맨드)
- 🔧 setup.sh + setup.ps1 (크로스플랫폼 지원)
- 📜 Bash/PowerShell hook 스크립트 각 4개
  - session-start, pre-compact, session-complete
  - lib/utils (공유 유틸리티)
- 📄 references/claude-md-template.md (템플릿 분리)
- 📚 CLAUDE.md, README.md, README.ko.md 업데이트

## Implementation

- Bash + PowerShell dual runtime (Windows/Linux/macOS 지원)
- Context persistence hooks (SessionStart, PreCompact, Stop)
- CLAUDE.md template with Skill Invocation Guidelines
- agents.md outperforms skills 연구 기반 설계

## File Structure

```
skills/project-setup/
├── SKILL.md
├── scripts/ (setup.sh, setup.ps1)
├── references/ (claude-md-template.md)
└── assets/hooks/ (8 hook scripts)
```

## Testing

- ✅ Bash hooks 실행 검증 (setup, session-start, pre-compact, session-complete, prune)
- ✅ Skill 감사 완료 (plugin-dev:skill-auditor)