### PR TITLE
fix: plugin.json 추가 및 marketplace.json source 형식 수정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,7 @@
   "plugins": [
     {
       "name": "csharp-marketplace",
-      "source": {
-        "source": "github",
-        "repo": "JeongHeonK/c-sharp-custom-marketplace"
-      },
+      "source": ".",
       "description": "C#/.NET 및 WPF 개발을 위한 플러그인. Modern C# 12/13, SOLID, GoF 디자인 패턴, CommunityToolkit.Mvvm 기반의 고품질 코드 작성 지원.",
       "version": "1.8.0",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "csharp-marketplace",
+  "description": "C#/.NET 및 WPF 개발을 위한 플러그인. Modern C# 12/13, SOLID, GoF 디자인 패턴, CommunityToolkit.Mvvm 기반의 고품질 코드 작성 지원.",
+  "version": "1.8.0",
+  "author": {
+    "name": "JeongHeonK"
+  },
+  "skills": "./skills/"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ rules/    → 스킬 내부 knowledge-base (skills/*/rules/)
 │   │   └── assets/hooks/         # hook 스크립트 (.sh + .ps1)
 │   └── wpf-mvvm-generator/SKILL.md
 ├── .claude-plugin/
+│   ├── plugin.json               # 플러그인 메타데이터
 │   └── marketplace.json          # 마켓플레이스 매니페스트
 ├── .mcp.json                     # MCP 서버 설정 (context7)
 ├── README.md                     # 영문 문서
@@ -100,11 +101,12 @@ allowed-tools:
 
 ## Version Management
 
-버전 변경 시 다음 3곳을 동시에 업데이트:
+버전 변경 시 다음 4곳을 동시에 업데이트:
 
-1. `.claude-plugin/marketplace.json` — `metadata.version` + `plugins[0].version`
-2. `CLAUDE.md` — Overview 섹션의 버전 표기
-3. `README.md` / `README.ko.md` — 배지 및 Changelog 섹션
+1. `.claude-plugin/plugin.json` — `version`
+2. `.claude-plugin/marketplace.json` — `metadata.version` + `plugins[0].version`
+3. `CLAUDE.md` — Overview 섹션의 버전 표기
+4. `README.md` / `README.ko.md` — 배지 및 Changelog 섹션
 
 ## Development Guidelines
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -82,6 +82,7 @@ npx skills add JeongHeonK/c-sharp-custom-marketplace --skill csharp-refactor wpf
 ```
 c-sharp-marketplace/
 ├── .claude-plugin/
+│   ├── plugin.json          # 플러그인 메타데이터
 │   └── marketplace.json     # 마켓플레이스 매니페스트
 ├── skills/
 │   ├── csharp-best-practices/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ When installing via the `/plugin` UI, you can choose the scope:
 ```
 c-sharp-marketplace/
 ├── .claude-plugin/
+│   ├── plugin.json          # Plugin metadata
 │   └── marketplace.json     # Marketplace manifest
 ├── skills/
 │   ├── csharp-best-practices/


### PR DESCRIPTION
## Summary

- `.claude-plugin/plugin.json` 신규 생성 (`/plugin` UI 플러그인 메타데이터 인식용)
- `marketplace.json`의 `plugins[0].source`를 GitHub 객체에서 `"."` 로 변경 (공식 마켓플레이스 형식 준수)
- `CLAUDE.md`, `README.md`, `README.ko.md` 문서 업데이트

## 참고

`npx skills`는 `~/.agents/.skill-lock.json`의 `skillFolderHash`로 업데이트를 감지하며, `plugin.json`의 version 필드를 사용하지 않음.
`/plugin` UI는 `~/.claude/plugins/installed_plugins.json`에서 version 기반으로 관리.

## Test plan

- [x] `npx skills add JeongHeonK/c-sharp-custom-marketplace` 설치 확인
- [x] `~/.agents/.skill-lock.json`에 source, skillFolderHash 정상 기록 확인
- [x] `npx skills check` — "All skills are up to date" 확인

Closes #15